### PR TITLE
Removed using ReferenceFasta struct, pass files directly instead

### DIFF
--- a/gatk/CombineVariants.wdl
+++ b/gatk/CombineVariants.wdl
@@ -7,13 +7,13 @@ version 1.0
 # Example: https://software.broadinstitute.org/wdl/documentation/article?id=7615
 # -------------------------------------------------------------------------------------------------
 
-import "https://raw.githubusercontent.com/genomics-geek/bfx-tools-wdl/master/structs/Resources.wdl"
-
 task CombineVariants {
   input {
     File ? java
     File gatk
-    ReferenceFasta reference
+    File reference
+    File reference_idx
+    File reference_dict
 
     String filename_prefix
     Array[String] input_files # NOTE: This allows us to add tagging. That's why its a string
@@ -55,7 +55,9 @@ task CombineVariants {
   parameter_meta {
     java: "Path to Java."
     gatk: "GATK jar file."
-    reference: "ReferenceFasta struct that contains Reference sequence file, index (.fai), and dict (.dict)."
+    reference: "Reference sequence file."
+    reference_idx: "Reference sequence index (.fai)."
+    reference_dict: "Reference sequence dict (.dict)."
     filename_prefix: "Prefix of the output VCF filename."
     input_files: "Two or more VCF files."
     input_idx_files: "VCF index files (.tbi)."

--- a/gatk/DepthOfCoverage.wdl
+++ b/gatk/DepthOfCoverage.wdl
@@ -7,13 +7,13 @@ version 1.0
 # Example: https://software.broadinstitute.org/wdl/documentation/article?id=7615
 # -------------------------------------------------------------------------------------------------
 
-import "https://raw.githubusercontent.com/genomics-geek/bfx-tools-wdl/master/structs/Resources.wdl"
-
 task DepthOfCoverage {
   input {
     File ? java
     File gatk
-    ReferenceFasta reference
+    File reference
+    File reference_idx
+    File reference_dict
 
     Array[File] intervals
     File ? gene_list
@@ -37,7 +37,7 @@ task DepthOfCoverage {
       -jar ${gatk} \
       -T DepthOfCoverage \
       ${default="-omitBaseOutput -omitLocusTable" userString} \
-      -R ${reference.reference} \
+      -R ${reference} \
       ${"-geneList " + gene_list} \
       ${default="15" sep=" " prefix("-ct ", summary_coverage_threshold)} \
       ${sep=" " prefix("-I ", bam_files)} \
@@ -60,7 +60,9 @@ task DepthOfCoverage {
   parameter_meta {
     java: "Path to Java."
     gatk: "GATK jar file."
-    reference: "ReferenceFasta struct that contains Reference sequence file, index (.fai), and dict (.dict)."
+    reference: "Reference sequence file."
+    reference_idx: "Reference sequence index (.fai)."
+    reference_dict: "Reference sequence dict (.dict)."
     intervals: "One or more genomic intervals over which to operate."
     gene_list: "Calculate coverage statistics over this list of genes"
     sample_id: "prefix for output files"

--- a/gatk/GenotypeGVCFs.wdl
+++ b/gatk/GenotypeGVCFs.wdl
@@ -7,13 +7,13 @@ version 1.0
 # Example: https://software.broadinstitute.org/wdl/documentation/article?id=7615
 # -------------------------------------------------------------------------------------------------
 
-import "https://raw.githubusercontent.com/genomics-geek/bfx-tools-wdl/master/structs/Resources.wdl"
-
 task GenotypeGVCFs {
   input {
     File ? java
     File gatk
-    ReferenceFasta reference
+    File reference
+    File reference_idx
+    File reference_dict
 
     File ? dbsnp
     File ? dbsnp_idx
@@ -42,7 +42,7 @@ task GenotypeGVCFs {
       -stand_call_conf ${default="10.0" stand_call_conf} \
       ${"--dbsnp " + dbsnp} \
       -nt ${default=1 cpu} \
-      -R ${reference.reference} \
+      -R ${reference} \
       ${sep=" " prefix("--variant ", gvcf_files)} \
       ${sep=" " prefix("--intervals ", intervals)} \
       -o ${vcf_filename}
@@ -61,7 +61,9 @@ task GenotypeGVCFs {
   parameter_meta {
     java: "Path to Java."
     gatk: "GATK jar file."
-    reference: "ReferenceFasta struct that contains Reference sequence file, index (.fai), and dict (.dict)."
+    reference: "Reference sequence file."
+    reference_idx: "Reference sequence index (.fai)."
+    reference_dict: "Reference sequence dict (.dict)."
     intervals: "One or more genomic intervals over which to operate."
     cohort_id: "Prefix of the output VCF filename."
     gvcf_files: "One or more gVCF files."

--- a/gatk/HaplotypeCallerERC.wdl
+++ b/gatk/HaplotypeCallerERC.wdl
@@ -10,13 +10,13 @@ version 1.0
 #  * Naming your output file using the .g.vcf extension will automatically set the appropriate values  for --variant_index_type and --variant_index_parameter
 # -------------------------------------------------------------------------------------------------
 
-import "https://raw.githubusercontent.com/genomics-geek/bfx-tools-wdl/master/structs/Resources.wdl"
-
 task HaplotypeCallerERC {
   input {
     File ? java
     File gatk
-    ReferenceFasta reference
+    File reference
+    File reference_idx
+    File reference_dict
 
     File ? dbsnp
     File ? dbsnp_idx
@@ -43,7 +43,7 @@ task HaplotypeCallerERC {
       ${userString} \
       -nct ${default=1 cpu} \
       ${"--dbsnp " + dbsnp} \
-      -R ${reference.reference} \
+      -R ${reference} \
       -I ${bam_file} \
       ${sep=" " prefix("--intervals ", intervals)} \
       -o ${gvcf_filename}
@@ -62,7 +62,9 @@ task HaplotypeCallerERC {
   parameter_meta {
     java: "Path to Java."
     gatk: "GATK jar file."
-    reference: "ReferenceFasta struct that contains Reference sequence file, index (.fai), and dict (.dict)."
+    reference: "Reference sequence file."
+    reference_idx: "Reference sequence index (.fai)."
+    reference_dict: "Reference sequence dict (.dict)."
     dbsnp: "dbSNP VCF file."
     dbsnp_idx: "dbSNP VCF index file (.tbi)."
     intervals: "One or more genomic intervals over which to operate."

--- a/gatk/SelectVariants.wdl
+++ b/gatk/SelectVariants.wdl
@@ -7,13 +7,13 @@ version 1.0
 # Example: https://software.broadinstitute.org/wdl/documentation/article?id=7615
 # -------------------------------------------------------------------------------------------------
 
-import "https://raw.githubusercontent.com/genomics-geek/bfx-tools-wdl/master/structs/Resources.wdl"
-
 task SelectVariants {
   input {
     File ? java
     File gatk
-    ReferenceFasta reference
+    File reference
+    File reference_idx
+    File reference_dict
 
     Array[File] intervals
     File input_file
@@ -36,7 +36,7 @@ task SelectVariants {
       -Xmx${default=4 memory}g \
       -jar ${gatk} \
       -T SelectVariants ${userString} \
-      -R ${reference.reference} \
+      -R ${reference} \
       -nt ${default=1 cpu} \
       --variant ${input_file} \
       ${sep=" " prefix("--intervals ", intervals)} \
@@ -59,7 +59,9 @@ task SelectVariants {
   parameter_meta {
     java: "Path to Java."
     gatk: "GATK jar file."
-    reference: "ReferenceFasta struct that contains Reference sequence file, index (.fai), and dict (.dict)."
+    reference: "Reference sequence file."
+    reference_idx: "Reference sequence index (.fai)."
+    reference_dict: "Reference sequence dict (.dict)."
     intervals: "One or more genomic intervals over which to operate."
     input_file: "One VCF file."
     input_idx_file: "VCF index file (.tbi)."

--- a/gatk/VariantFiltration.wdl
+++ b/gatk/VariantFiltration.wdl
@@ -7,13 +7,13 @@ version 1.0
 # Example: https://software.broadinstitute.org/wdl/documentation/article?id=7615
 # -------------------------------------------------------------------------------------------------
 
-import "https://raw.githubusercontent.com/genomics-geek/bfx-tools-wdl/master/structs/Resources.wdl"
-
 task VariantFiltration {
   input {
     File ? java
     File gatk
-    ReferenceFasta reference
+    File reference
+    File reference_idx
+    File reference_dict
 
     File input_file
     File input_idx_file
@@ -36,7 +36,7 @@ task VariantFiltration {
       -jar ${gatk} \
       -T VariantFiltration \
       ${userString} \
-      -R ${reference.reference} \
+      -R ${reference} \
       --variant ${input_file} \
       --clusterWindowSize ${default=10 clusterWindowSize} \
       ${default="" "--filterExpression " + filterExpression} \
@@ -57,7 +57,9 @@ task VariantFiltration {
   parameter_meta {
     java: "Path to Java."
     gatk: "GATK jar file."
-    reference: "ReferenceFasta struct that contains Reference sequence file, index (.fai), and dict (.dict)."
+    reference: "Reference sequence file."
+    reference_idx: "Reference sequence index (.fai)."
+    reference_dict: "Reference sequence dict (.dict)."
     input_file: "Two or more VCF files."
     input_idx_file: "VCF index files (.tbi)."
     clusterWindowSize: "The window size (in bases) in which to evaluate clustered SNPs."

--- a/picard/BedToIntervalList.wdl
+++ b/picard/BedToIntervalList.wdl
@@ -6,13 +6,11 @@ version 1.0
 # Documentation: https://broadinstitute.github.io/picard/command-line-overview.html#BedToIntervalList
 # -------------------------------------------------------------------------------------------------
 
-import "https://raw.githubusercontent.com/genomics-geek/bfx-tools-wdl/master/structs/Resources.wdl"
-
 task BedToIntervalList {
   input {
     File ? java
     File picard
-    ReferenceFasta reference
+    File reference_dict
 
     File bed_file
 
@@ -31,7 +29,7 @@ task BedToIntervalList {
       -Xmx${default=4 memory}g \
       -jar ${picard} BedToIntervalList \
       ${default="VALIDATION_STRINGENCY=LENIENT" "VALIDATION_STRINGENCY=" + validation_stringency} \
-      SEQUENCE_DICTIONARY=${reference.reference_dict} \
+      SEQUENCE_DICTIONARY=${reference_dict} \
       ${default="UNIQUE=true" true="UNIQUE=true" false="" unique} \
       INPUT=${bed_file} \
       OUTPUT=${output_filename} \
@@ -50,7 +48,7 @@ task BedToIntervalList {
   parameter_meta {
     java: "Path to Java."
     picard: "Picard jar file."
-    reference: "ReferenceFasta struct that contains Reference sequence file, index (.fai), and dict (.dict)."
+    reference_dict: "Reference sequence dict (.dict)."
     bed_file: "BED file to convert."
     validation_stringency: "Validation stringency for all SAM files read by this program. Setting stringency to SILENT can improve performance when processing a BAM file in which variable-length data (read, qualities, tags) do not otherwise need to be decoded."
     unique: "Unique the output interval list by merging overlapping regions."

--- a/picard/CollectHsMetrics.wdl
+++ b/picard/CollectHsMetrics.wdl
@@ -6,13 +6,12 @@ version 1.0
 # Documentation: http://broadinstitute.github.io/picard/command-line-overview.html#CollectHsMetrics
 # -------------------------------------------------------------------------------------------------
 
-import "https://raw.githubusercontent.com/genomics-geek/bfx-tools-wdl/master/structs/Resources.wdl"
-
 task CollectHsMetrics {
   input {
     File ? java
     File picard
-    ReferenceFasta reference
+    File reference
+    File reference_idx
 
     String sample_id
     File input_file
@@ -35,7 +34,7 @@ task CollectHsMetrics {
       -Xmx${default=4 memory}g \
       -jar ${picard} CollectHsMetrics \
       VALIDATION_STRINGENCY=${default="LENIENT" validation_stringency} \
-      REFERENCE_SEQUENCE=${reference.reference} \
+      REFERENCE_SEQUENCE=${reference} \
       INPUT=${input_file} \
       BAIT_INTERVALS=${bait_intervals} \
       TARGET_INTERVALS=${target_intervals} \
@@ -57,7 +56,8 @@ task CollectHsMetrics {
   parameter_meta {
     java: "Path to Java."
     picard: "Picard jar file."
-    reference: "ReferenceFasta struct that contains Reference sequence file, index (.fai), and dict (.dict)."
+    reference: "Reference sequence file."
+    reference_idx: "Reference sequence index (.fai)."
     sample_id: "prefix for output files."
     input_file: "Sorted BAM file."
     input_idx_file: "Sorted BAM index file."

--- a/picard/MarkDuplicates.wdl
+++ b/picard/MarkDuplicates.wdl
@@ -6,13 +6,12 @@ version 1.0
 # Documentation: https://broadinstitute.github.io/picard/command-line-overview.html#MarkDuplicates
 # -------------------------------------------------------------------------------------------------
 
-import "https://raw.githubusercontent.com/genomics-geek/bfx-tools-wdl/master/structs/Resources.wdl"
-
 task MarkDuplicates {
   input {
     File ? java
     File picard
-    ReferenceFasta reference
+    File reference
+    File reference_idx
 
     String sample_id
     File input_file
@@ -37,7 +36,7 @@ task MarkDuplicates {
       -Xmx${default=4 memory}g \
       -jar ${picard} MarkDuplicates \
       VALIDATION_STRINGENCY=${default="LENIENT" validation_stringency} \
-      REFERENCE_SEQUENCE=${reference.reference} \
+      REFERENCE_SEQUENCE=${reference} \
       INPUT=${input_file} \
       REMOVE_DUPLICATES=${default=false remove_duplicates} \
       ${"ASSUME_SORT_ORDER=" + sort_order} \
@@ -61,7 +60,8 @@ task MarkDuplicates {
   parameter_meta {
     java: "Path to Java."
     picard: "Picard jar file."
-    reference: "ReferenceFasta struct that contains Reference sequence file, index (.fai), and dict (.dict)."
+    reference: "Reference sequence file."
+    reference_idx: "Reference sequence index (.fai)."
     sample_id: "prefix for output files."
     input_file: "SAM or BAM file."
     validation_stringency: "Validation stringency for all SAM files read by this program. Setting stringency to SILENT can improve performance when processing a BAM file in which variable-length data (read, qualities, tags) do not otherwise need to be decoded."


### PR DESCRIPTION
Pass exact reference files to task to avoid confusion later...