### PR TITLE
Update CombineFastQ.wdl

### DIFF
--- a/utilities/CombineFastQ.wdl
+++ b/utilities/CombineFastQ.wdl
@@ -12,11 +12,11 @@ task CombineFastQ {
   String output_filename = basename(fastq)
 
   command <<<
-    if [[ "${files}" == "0" ]]
+    if [[ "~{files}" == "0" ]]
     then
-      ln -s ${fastq} ${output_filename}
+      ln -s ~{fastq} ~{output_filename}
     else
-      cat ${fastq} ${sep=" " additional_fastq} > ${output_filename}
+      cat ~{fastq} ~{sep=" " additional_fastq} > ~{output_filename}
     fi
   >>>
 


### PR DESCRIPTION
According to WDL language specification v1, command section now requires `~` instead of `$` for expression when using `<<<`. See [this](https://github.com/openwdl/wdl/blob/master/versions/1.0/SPEC.md#command-section)

